### PR TITLE
Add should_not_appear functionality

### DIFF
--- a/hitchselenium/step_library.py
+++ b/hitchselenium/step_library.py
@@ -174,7 +174,30 @@ class SeleniumStepLibrary(object):
                 EC.visibility_of_element_located((By.XPATH, full_xpath))
             )
 
-        
+    def should_not_appear(self, item):
+        """Wait and make sure an item does NOT appear.
+
+           Note that this makes use of 'wait_to_appear', and so if the item
+           in question takes longer to appear than wait_to_appear takes to
+           time out then it will be considered not to have appeared.
+
+           * If there are no spaces in item, waits for element with HTML id
+             "item" to appear.
+           * "first class1" - waits for first item with  HTML class "class1"
+             to appear.
+           * "2nd class1 class2" - waits for the 2nd item with HTML classes
+             class1 and class2 to appear.
+           * "last class1 class2" - waits for the last element with classes
+             class1 and class2 to appear.
+        """
+        try:
+            self.wait_to_appear(item)
+            raise RuntimeError(
+                "Item {} should not have appeared".format(item)
+            )
+        except TimeoutException:
+            pass
+
     def wait_for_form_item_to_contain(self, item=None, text=None):
         item = HitchSeleniumItem(item)
         if item.is_id:


### PR DESCRIPTION
From docstring:
           Note that this makes use of 'wait_to_appear', and so if the item
           in question takes longer to appear than wait_to_appear takes to
           time out then it will be considered not to have appeared.

I've tried to make it pep8 compliant, but haven't linted the file as a lot of the rest of it will fail.

I've copied the step_library.py (where the change is) into my environment with hitchselenium (0.4.9) and observed it working, so it at least is possible for it to work, but I've not conducted more exhaustive tests.
